### PR TITLE
Fixes simple geojson styling

### DIFF
--- a/nextplot/geojson.py
+++ b/nextplot/geojson.py
@@ -79,7 +79,7 @@ class StyledGeoJson(JSCSSMixin, Layer):
             var {{ this.get_name() }} = L.geoJson({{ this.data }},
                 {
                     useSimpleStyle: true,
-                    useMakiMarkers: true
+                    useMakiMarkers: false
                 }
             ).addTo({{ this._parent.get_name() }});
         {% endmacro %}


### PR DESCRIPTION
# Description

Fixes simple geojson styling (`nextplot geojson ... --style`) by deactivating the maki markers that have become unavailable for direct access.

## Changes

- Fixes simple geojson styling by using only simple markers