### PR TITLE
Renames publish workflow to release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
-name: publish
+name: release
+run-name: Release ${{ inputs.VERSION }} (pre-release - ${{ inputs.IS_PRE_RELEASE }}) by @${{ github.actor }} from ${{ github.ref_name }}
 
 on:
     workflow_dispatch:
@@ -79,7 +80,7 @@ jobs:
               run: python -m build
               working-directory: ./nextplot
 
-    publish: # This job is used to publish the release to PyPI/TestPyPI
+    release: # This job is used to publish the release to PyPI/TestPyPI
         runs-on: ubuntu-latest
         needs: bump
         strategy:
@@ -129,8 +130,8 @@ jobs:
 
     notify:
         runs-on: ubuntu-latest
-        needs: publish
-        if: ${{ needs.publish.result == 'success' && inputs.IS_PRE_RELEASE == false }}
+        needs: release
+        if: ${{ needs.release.result == 'success' && inputs.IS_PRE_RELEASE == false }}
         steps:
             - name: notify slack
               run: |


### PR DESCRIPTION
# Description

Renames the `publish` workflow to `release` for harmonization with our other repositories.

## Changes

- Changed job name from `publish` to `release`.
- Added `run-name` to include dynamic release version and pre-release status.